### PR TITLE
Indicator not appearing on repeated imports fix

### DIFF
--- a/gta/map_importer.py
+++ b/gta/map_importer.py
@@ -128,6 +128,7 @@ class Map_Import_Operator(bpy.types.Operator):
 
         if self._calcs_done:
             self.cancel(context)
+            return {'FINISHED'}
 
         return {'PASS_THROUGH'}
 


### PR DESCRIPTION
Explained in the title. Fixes the little progress indicator that appears on your cursor during importing map segments. 👌
Actually I think the timer kept running and calling this function, because we didn't tell it the operator's finished. 😄 Now that's fixed.