### PR TITLE
map importer index check fix

### DIFF
--- a/gta/map_importer.py
+++ b/gta/map_importer.py
@@ -38,7 +38,7 @@ class Map_Import_Operator(bpy.types.Operator):
     def import_object(self, context):
 
         # Are there any IPL entries left to import?
-        if self._inst_index >= len(self._object_instances) - 1:
+        if self._inst_index > len(self._object_instances) - 1:
             self._calcs_done = True
             return
 


### PR DESCRIPTION
Sorry for all the PRs. Hopefully this is the last one.

The map importer was quitting before it imported the last ipl entry. That's now fixed.
I only noticed because the last ipl entry in landsw.ipl is a huge building, which left a giant hole in the ground.

If you know of a better way to check for this kind of stuff (is index in a list?) you can definitely replace it.